### PR TITLE
Add email permissions to API request

### DIFF
--- a/src/directives/angular-linkedin-login.js
+++ b/src/directives/angular-linkedin-login.js
@@ -23,7 +23,8 @@ angular.module('linkedinExample').directive('linkedinLogin',
                                 IN.init({
                                     onLoad: "linkedinLibInit",
                                     api_key: "LINKEDIN_API_KEY",
-                                    credentials_cookie: true
+                                    credentials_cookie: true,
+                                    scope: "r_fullprofile r_emailaddress"
                                 });
                             });
                 


### PR DESCRIPTION
You can't receive the email address of a user without this permission grant being requested.
